### PR TITLE
Add power/voltage/current sensors from the long status frame and optional RS-485 direction pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,40 @@ climate:
 
 ```
 
+### Electrical sensors (power, voltage, current)
+
+`power` (W), `voltage` (V) and `current` (A) sensors are created by default, like the other status sensors, and are populated only when the indoor unit sends the long status frame (see the protocol section below). The current reported by the AC is an integer, so a finer value can be derived as power / voltage with a template sensor. For the Home Assistant Energy dashboard combine `power` with `total_daily_energy`; add a `heartbeat` filter so the energy keeps integrating while the power value is constant:
+
+```yaml
+time:
+  - platform: homeassistant
+
+climate:
+  - platform: ac_hi
+    # ...
+    power:
+      name: "Power"
+      id: ac_power
+      filters:
+        - heartbeat: 30s
+    voltage:
+      name: "Voltage"
+    current:
+      name: "Current (raw)"
+
+sensor:
+  - platform: total_daily_energy
+    name: "Energy Daily"
+    power_id: ac_power
+    method: trapezoid
+    unit_of_measurement: kWh
+    device_class: energy
+    state_class: total_increasing
+    accuracy_decimals: 3
+    filters:
+      - multiply: 0.001
+```
+
 configuration for the iFeel function (uses mqtt, an external IR transmitter, and any thermometer from home assistant)
 
 ```yaml
@@ -300,6 +334,12 @@ When the AC receives a short query (0x66 frame), it responds with a long status 
 | 43 | Compressor actual frequency | Hz |
 | 44 | Outdoor air temperature | °C (signed int8\_t) |
 | 45 | Outdoor condenser temperature | °C (signed int8\_t) |
+| 50 | Mains voltage | V (byte 51 is always 0, so possibly uint16 LE). Long status frame only |
+| 55–56 | Input power | W, **uint16 big-endian** (55 = high byte, 56 = low byte). Long status frame only |
+| 60 | Input current | A, integer (rounded). Long status frame only |
+| 144–145 | Copy of the input power | uint16 little-endian, same value as bytes 55–56 |
+
+Some indoor units answer the status query with a **150-byte frame** (byte 4 = 0x8D). Bytes 50, 55–56 and 60 of that frame carry the electrical data that the original Wi‑Fi module exposes to the cloud as voltage / power (verified on a Hisense split with the AEH‑W4G1 module: 20 Hz → 110 W / 0 A, 46 Hz → 1740 W / 8 A at 226 V; power / voltage matches the current byte). Units that reply with the short frame do not have these fields and the related sensors stay unknown.
 
 ### Write command (command 0x65)
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ The component exposes a standard Home Assistant Climate entity, along with a set
 
 > ⚠️ The AC uses 5V logic levels on its RS‑485 port. Make sure your transceiver is 3.3V‑tolerant if you power the ESP from 3.3V.
 
+Transceivers with automatic direction switching (TXD/RXD only) need no extra wiring. A bare MAX485 (DI/DE/RE/RO pins) needs the driver enabled while transmitting: wire DE and RE together to one GPIO and set `flow_control_pin`, or keep them separate and set `de_pin` and `re_pin`. The component drives the pin(s) HIGH for the duration of each frame and LOW otherwise.
+
+```yaml
+climate:
+  - platform: ac_hi
+    # ...
+    flow_control_pin: GPIO21   # DE + RE bridged
+    # or: de_pin: GPIO21 / re_pin: GPIO17
+```
+
 <img width="1055" height="1053" alt="image" src="https://github.com/user-attachments/assets/933c420f-395c-4ee8-a7df-6d1056cbf31e" />
 
 

--- a/components/ac_hi/ac_hi.cpp
+++ b/components/ac_hi/ac_hi.cpp
@@ -2379,6 +2379,15 @@ void ACHIClimate::parse_status_102_(const std::vector<uint8_t> &b) {
       : (power_on_ ? target_c_ : target_for_mode_(mode_, d_target_c_));
   publish_sensor_if_changed_(set_temp_sensor_, published_setpoint);
   publish_sensor_if_changed_(room_temp_sensor_, current_temperature);
+  // Electrical data carried by the long (150-byte) status frame of some indoor units:
+  // byte 50 = mains voltage (V), bytes 55-56 = input power (W, big-endian),
+  // byte 60 = input current (A, integer). Units that reply with the short frame
+  // never reach this branch and the sensors simply stay unknown.
+  if (b.size() > 60) {
+    publish_sensor_if_changed_(voltage_sensor_, static_cast<float>(b[50] | (b[51] << 8)));
+    publish_sensor_if_changed_(power_sensor_, static_cast<float>((b[55] << 8) | b[56]));
+    publish_sensor_if_changed_(current_sensor_, static_cast<float>(b[60]));
+  }
   publish_sensor_if_changed_(wind_code_sensor_, b[IDX_WIND]);
   publish_sensor_if_changed_(sleep_code_sensor_, b[IDX_SLEEP]);
   publish_sensor_if_changed_(mode_code_sensor_, (b[IDX_POWER_MODE] >> 4) & 0x0F);

--- a/components/ac_hi/ac_hi.cpp
+++ b/components/ac_hi/ac_hi.cpp
@@ -167,6 +167,12 @@ void ACHISleepProgramSelect::control(const std::string &value) {
 // ---- ACHIClimate implementation ----
 
 void ACHIClimate::setup() {
+  for (GPIOPin *p : {flow_control_pin_, de_pin_, re_pin_}) {
+    if (p != nullptr) {
+      p->setup();
+      p->digital_write(false);  // receive
+    }
+  }
   // Register custom presets on the Climate entity, not on ClimateTraits.
   // ClimateTraits::set_supported_custom_presets() is deprecated and will be removed in ESPHome 2026.11.0.
   if (enable_presets_) {
@@ -1402,8 +1408,10 @@ void ACHIClimate::send_logical_frame_(const std::vector<uint8_t> &logical, const
              (unsigned) logical.size(), (unsigned) wire.size());
     log_frame_("TX wire", wire);
   }
+  rs485_tx_(true);
   for (auto b : wire) write_byte(b);
   flush();
+  rs485_tx_(false);
 }
 
 // ---- RX frame parsing ----

--- a/components/ac_hi/ac_hi.h
+++ b/components/ac_hi/ac_hi.h
@@ -4,6 +4,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/gpio.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/select/select.h"
 #include "esphome/components/remote_base/remote_base.h"
@@ -259,6 +260,12 @@ class ACHIClimate : public climate::Climate, public PollingComponent, public uar
 
   // Configuration
   void set_enable_presets(bool v) { enable_presets_ = v; }
+  // Optional RS-485 half-duplex direction control for transceivers without
+  // automatic direction switching (e.g. bare MAX485): either a single
+  // flow_control_pin wired to DE+RE, or separate de_pin / re_pin.
+  void set_flow_control_pin(GPIOPin *pin) { flow_control_pin_ = pin; }
+  void set_de_pin(GPIOPin *pin) { de_pin_ = pin; }
+  void set_re_pin(GPIOPin *pin) { re_pin_ = pin; }
 #ifdef USE_SENSOR
   void set_pipe_sensor(sensor::Sensor *s) { pipe_sensor_ = s; }
 #else
@@ -430,6 +437,16 @@ class ACHIClimate : public climate::Climate, public PollingComponent, public uar
   std::vector<uint8_t> rx_;
   size_t rx_start_{0};
 
+  GPIOPin *flow_control_pin_{nullptr};
+  GPIOPin *de_pin_{nullptr};
+  GPIOPin *re_pin_{nullptr};
+  // HIGH while transmitting, LOW otherwise. /RE is active low, so driving it
+  // HIGH during TX also mutes the receiver and avoids echoing our own frame.
+  void rs485_tx_(bool tx) {
+    if (flow_control_pin_ != nullptr) flow_control_pin_->digital_write(tx);
+    if (de_pin_ != nullptr) de_pin_->digital_write(tx);
+    if (re_pin_ != nullptr) re_pin_->digital_write(tx);
+  }
   bool writing_lock_{false};
   uint32_t write_lock_time_{0};               // when lock was set
 

--- a/components/ac_hi/ac_hi.h
+++ b/components/ac_hi/ac_hi.h
@@ -300,6 +300,9 @@ class ACHIClimate : public climate::Climate, public PollingComponent, public uar
   // Legacy YAML key `compressor_frequency`; retained as an alias for byte 43.
   void set_compr_freq_sensor(sensor::Sensor *s) { compressor_freq_sensor_ = s; }
   void set_outdoor_temp_sensor(sensor::Sensor *s) { outdoor_temp_sensor_ = s; }
+  void set_power_sensor(sensor::Sensor *s) { power_sensor_ = s; }
+  void set_voltage_sensor(sensor::Sensor *s) { voltage_sensor_ = s; }
+  void set_current_sensor(sensor::Sensor *s) { current_sensor_ = s; }
   void set_outdoor_cond_temp_sensor(sensor::Sensor *s) { outdoor_cond_temp_sensor_ = s; }
   void set_compressor_exhaust_temp_sensor(sensor::Sensor *s) { compressor_exhaust_temp_sensor_ = s; }
   void set_indoor_humidity_setting_sensor(sensor::Sensor *s) { indoor_humidity_setting_sensor_ = s; }
@@ -624,6 +627,9 @@ class ACHIClimate : public climate::Climate, public PollingComponent, public uar
   // Legacy byte-43 sensor configured through `compressor_frequency`.
   sensor::Sensor *compressor_freq_sensor_{nullptr};
   sensor::Sensor *outdoor_temp_sensor_{nullptr};
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *outdoor_cond_temp_sensor_{nullptr};
   sensor::Sensor *compressor_exhaust_temp_sensor_{nullptr};
   sensor::Sensor *indoor_humidity_setting_sensor_{nullptr};

--- a/components/ac_hi/climate.py
+++ b/components/ac_hi/climate.py
@@ -64,6 +64,9 @@ CONF_COMP_FR_COMMAND = "compressor_frequency_command"
 # Backward-compatible alias for byte 43 used by older YAML configurations.
 CONF_COMP_FR = "compressor_frequency"
 CONF_OUTDOOR_TEMP = "outdoor_temperature"
+CONF_POWER = "power"
+CONF_VOLTAGE = "voltage"
+CONF_CURRENT = "current"
 CONF_OUTDOOR_COND_TEMP = "outdoor_condenser_temperature"
 CONF_COMPRESSOR_EXHAUST_TEMP = "compressor_exhaust_temperature"
 
@@ -156,6 +159,16 @@ CONFIG_SCHEMA = BASE_CLIMATE_SCHEMA.extend({
         unit_of_measurement="Hz",
         accuracy_decimals=0,
         icon="mdi:sine-wave",
+    ),
+    # Electrical data (long status frame only; see README "Status response")
+    cv.Optional(CONF_POWER, default={CONF_NAME: "Power"}): sensor.sensor_schema(
+        unit_of_measurement="W", device_class="power", state_class="measurement", accuracy_decimals=0,
+    ),
+    cv.Optional(CONF_VOLTAGE, default={CONF_NAME: "Voltage"}): sensor.sensor_schema(
+        unit_of_measurement="V", device_class="voltage", state_class="measurement", accuracy_decimals=0,
+    ),
+    cv.Optional(CONF_CURRENT, default={CONF_NAME: "Current"}): sensor.sensor_schema(
+        unit_of_measurement="A", device_class="current", state_class="measurement", accuracy_decimals=0,
     ),
     cv.Optional(CONF_OUTDOOR_TEMP, default={CONF_NAME: "Temperature Outdoor"}): sensor.sensor_schema(
         unit_of_measurement="°C",
@@ -343,6 +356,12 @@ async def to_code(config):
     if conf := config.get(CONF_COMP_FR):
         sens = await sensor.new_sensor(conf)
         cg.add(var.set_compr_freq_sensor(sens))
+
+    for key, setter in ((CONF_POWER, "set_power_sensor"), (CONF_VOLTAGE, "set_voltage_sensor"),
+                        (CONF_CURRENT, "set_current_sensor")):
+        if conf := config.get(key):
+            sens = await sensor.new_sensor(conf)
+            cg.add(getattr(var, setter)(sens))
 
     if conf := config.get(CONF_OUTDOOR_TEMP):
         sens = await sensor.new_sensor(conf)

--- a/components/ac_hi/climate.py
+++ b/components/ac_hi/climate.py
@@ -1,8 +1,12 @@
 import esphome.codegen as cg
 from esphome import automation
 import esphome.config_validation as cv
+from esphome import pins
 from esphome.components import climate, uart, sensor, binary_sensor, switch, select, text_sensor, remote_base
-from esphome.const import CONF_ID, CONF_UART_ID, CONF_NAME, CONF_TEMPERATURE, ENTITY_CATEGORY_CONFIG, ENTITY_CATEGORY_DIAGNOSTIC, ICON_LIGHTBULB
+from esphome.const import CONF_ID, CONF_UART_ID, CONF_NAME, CONF_TEMPERATURE, ENTITY_CATEGORY_CONFIG, ENTITY_CATEGORY_DIAGNOSTIC, ICON_LIGHTBULB, CONF_FLOW_CONTROL_PIN
+
+CONF_DE_PIN = "de_pin"
+CONF_RE_PIN = "re_pin"
 
 AUTO_LOAD = ["climate", "uart", "sensor", "binary_sensor", "switch", "select", "text_sensor", "remote_base"]
 
@@ -87,6 +91,10 @@ CONF_PSRAM_FREE = "psram_free"
 CONFIG_SCHEMA = BASE_CLIMATE_SCHEMA.extend({
     **BASE_CLIMATE_EXTRA,
     cv.Optional(CONF_ENABLE_PRESETS, default=True): cv.boolean,
+    # RS-485 direction control for transceivers without auto-direction
+    cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
+    cv.Optional(CONF_DE_PIN): pins.gpio_output_pin_schema,
+    cv.Optional(CONF_RE_PIN): pins.gpio_output_pin_schema,
     cv.Optional(CONF_IR_TRANSMITTER_ID): cv.use_id(remote_base.RemoteTransmitterBase),
     cv.Optional(CONF_IFEEL_MQTT_TOPIC): cv.string_strict,
     cv.Optional(CONF_IFEEL_MQTT_PAYLOAD, default="hex"): cv.one_of("hex", "json", lower=True),
@@ -288,6 +296,12 @@ async def to_code(config):
     cg.add(var.set_uart_parent(uart_comp))
 
     cg.add(var.set_enable_presets(config[CONF_ENABLE_PRESETS]))
+
+    for key, setter in ((CONF_FLOW_CONTROL_PIN, "set_flow_control_pin"),
+                        (CONF_DE_PIN, "set_de_pin"), (CONF_RE_PIN, "set_re_pin")):
+        if key in config:
+            pin = await cg.gpio_pin_expression(config[key])
+            cg.add(getattr(var, setter)(pin))
 
     if tx_id := config.get(CONF_IR_TRANSMITTER_ID):
         tx = await cg.get_variable(tx_id)


### PR DESCRIPTION
Two small, independent additions that came out of putting `ac_hi` on a Hisense wall split (Italy, ConnectLife generation, original module AEH-W4G1 replaced by an ESP32 + bare MAX485). Happy to split them into two PRs if you prefer.

## 1. Power, voltage and current sensors (commit 1)

On this unit the reply to the short status query (0x66/0x00) is a **150-byte frame** (byte 4 = 0x8D). The bytes above index 46, which the component does not decode, carry the electrical data that the original Wi-Fi module exposes to the cloud as voltage / power:

| Index | Meaning | Encoding | Observed |
|---|---|---|---|
| 50 (51) | Mains voltage | V, uint8 (byte 51 always 0, possibly uint16 LE) | 225–229 V |
| 55–56 | Input power | W, **uint16 big-endian** | 0x006E = 110 W, 0x021C = 540 W, 0x02E4 = 740 W, 0x0604 = 1540 W, 0x06CC = 1740 W |
| 60 | Input current | A, integer (rounded) | 0, 2, 3, 7, 8 A |
| 144–145 | Copy of the power value | uint16 little-endian | same values as 55–56 |

Cross-checks: the values co-vary with the compressor frequency (20 Hz → 110 W, 44–46 Hz → 1540–1740 W), power / voltage matches the current byte (740 / 226 = 3.3 → 3 A, 1740 / 226 = 7.7 → 8 A), and the same unit reported `f_electricity = 1510 W`, `f_votage = 223 V` through ConnectLife the same day with its original module.

The three sensors are created by default like the other status sensors and are published only when `b.size() > 60`, so units that reply with the short frame simply keep them unknown. README gets the byte table and an Energy-dashboard example (`total_daily_energy` + `heartbeat` filter, since the component only publishes on change).

Idle reference frame (20 Hz, 110 W, 226 V):

```
F4 F5 01 40 8D 01 00 FE 01 01 01 01 00 66 00 01
01 00 28 1A 1A 1A 80 80 00 01 A1 00 00 00 00 00
00 00 00 00 00 80 05 00 00 14 1E 00 1B 55 30 00
00 00 E2 00 00 00 00 00 6E 00 00 00 00 00 00 00
00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00
00 × 64
6E 00 07 68 F4 FB
```

## 2. Optional RS-485 direction pins (commit 2)

Bare MAX485 boards (DI/DE/RE/RO) need the driver enabled while transmitting. This adds optional `flow_control_pin` (DE+RE bridged) or separate `de_pin` / `re_pin`; they are driven HIGH around each transmitted frame in `send_logical_frame_()` and kept LOW otherwise. Driving /RE HIGH during TX also mutes the receiver, so the component never parses its own frame. Nothing changes when the options are not set.

## Testing

Both changes are running on the unit above (ESPHome 2026.8.2, Arduino framework, `wemos_d1_mini32`, DE/RE on separate GPIOs) for a day: climate control, presets, LED/sound switches and the new sensors all work; the energy counter feeds the HA Energy dashboard.

## Side note, not changed by this PR

On this unit the two outdoor temperatures look swapped: index 45 rose from 80 to 90 °C with load (compressor discharge behaviour) while index 46 stayed at 33–55 °C (condenser coil behaviour). Might be worth checking on other units before touching the labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
